### PR TITLE
Improve empty class warning wording

### DIFF
--- a/sass/utils/_variables.scss
+++ b/sass/utils/_variables.scss
@@ -11,7 +11,7 @@ $messages: (
   "advice": (
     "empty-class": (
       "fr": "Attribut [class] vide.\A Pourquoi tant de haine ?",
-      "en": "Missing [class] attribute.\A Why so much hatred?"
+      "en": "Empty [class] attribute.\A Why so much hatred?"
     ),
     "empty-id": (
       "fr": "Attribut [id] vide.\A Sérieusement ?",


### PR DESCRIPTION
Because it responds to the class attribute being empty, not on the non-presence of it.