### PR TITLE
Fixed issue for aria-hidden advice

### DIFF
--- a/sass/themes/_advice.scss
+++ b/sass/themes/_advice.scss
@@ -315,7 +315,7 @@ A `[hidden]` or `[aria-hidden]` may not be a good idea if hiding content.
 ```
 */
 [hidden]:not(:empty),
-[aria-hidden]:not(:empty) {
+[aria-hidden="true"]:not(:empty) {
   @include advice("hidden");
 }
 


### PR DESCRIPTION
If you have aria-hidden="false", it shouldn't be adviced as it is not hidden :)

So that's why I've updated the selector to [aria-hidden="true"] ;)

Test case : http://www.visionlaser.ch/fr/contact-vision-laser (main navigation on desktop)