### PR TITLE
Improved loop efficiency

### DIFF
--- a/test-assets/_footer.html
+++ b/test-assets/_footer.html
@@ -32,8 +32,10 @@
 
 
       function activeAnchor() {
-        $currentHref = document.getElementById("toc").getElementsByTagName("a");
-        for(i=0;i<$currentHref.length;i++) {
+        var $currentHref = document.getElementById("toc").getElementsByTagName("a");
+        var $length = $currentHref.length;
+        var i = 0;
+        for(;i<$length;i++) {
           if(document.location.href.indexOf($currentHref[i].href)>=0) {
             $currentHref[i].classList.add("active-test");
           }


### PR DESCRIPTION
We should calculate the length of `$currentHref` only once, not each time the loop increments `i`.