### PR TITLE
fix RGAA links

### DIFF
--- a/docs/build/advices.html
+++ b/docs/build/advices.html
@@ -182,7 +182,7 @@
 <h2>Description</h2>
 <p class="styleguide">Some ARIA roles should be unique: at least <code class="styleguide">[main]</code>, <code class="styleguide">[search]</code>, <code class="styleguide">[banner]</code>, <code class="styleguide">[contentinfo]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1210-a-dans-chaque-page-web-les-groupes-de-liens-importants-menu-barre-de-navigation-et-la-zone-de-contenu-sont-ils-identifis-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1210-a-dans-chaque-page-web-les-groupes-de-liens-importants-menu-barre-de-navigation-et-la-zone-de-contenu-sont-ils-identifis-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-12-10">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-12-10</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip</a></li>
 </ul>
 <h2>Selector</h2>
@@ -310,8 +310,8 @@
 <h2>Description</h2>
 <p class="styleguide">A link to a file should indicate the file format, the file size and if different from the main document, the file language.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-136-a-dans-chaque-page-web-pour-chaque-fichier-en-tlchargement-des-informations-relatives-sa-consultation-sont-elles-prsentes-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-136-a-dans-chaque-page-web-pour-chaque-fichier-en-tlchargement-des-informations-relatives-sa-consultation-sont-elles-prsentes-hors-cas-particuliers-</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-137-a-dans-chaque-page-web-chaque-document-bureautique-en-tlchargement-possde-t-il-si-ncessaire-une-version-accessible">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-137-a-dans-chaque-page-web-chaque-document-bureautique-en-tlchargement-possde-t-il-si-ncessaire-une-version-accessible</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-6">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-6</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-7">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-7</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H33.html">http://www.w3.org/TR/WCAG-TECHS/H33.html</a></li>
 </ul>
@@ -349,7 +349,7 @@
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">[hidden]</code> or <code class="styleguide">[aria-hidden]</code> may not be a good idea if hiding content.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1013-a-pour-chaque-page-web-les-textes-cachs-sont-ils-correctement-affichs-pour-tre-restitus-par-les-technologies-dassistance-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1013-a-pour-chaque-page-web-les-textes-cachs-sont-ils-correctement-affichs-pour-tre-restitus-par-les-technologies-dassistance-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-10-13">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-10-13</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 </ul>
 <h2>Selector</h2>
@@ -414,7 +414,7 @@ Otherwise you may annoy your users.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">[class]</code> or <code class="styleguide">[id]</code> containing search may carry the search ARIA <code class="styleguide">[role]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1210-a-dans-chaque-page-web-les-groupes-de-liens-importants-menu-barre-de-navigation-et-la-zone-de-contenu-sont-ils-identifis-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1210-a-dans-chaque-page-web-les-groupes-de-liens-importants-menu-barre-de-navigation-et-la-zone-de-contenu-sont-ils-identifis-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-12-10">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-12-10</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip</a></li>
 </ul>
 <h2>Selector</h2>
@@ -487,7 +487,7 @@ Otherwise you may annoy your users.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">[required]</code> or <code class="styleguide">[aria-required]</code> should be visually understandable.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1110-a-dans-chaque-formulaire-le-contrle-de-saisie-est-il-utilis-de-manire-pertinente-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1110-a-dans-chaque-formulaire-le-contrle-de-saisie-est-il-utilis-de-manire-pertinente-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-11-10">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-11-10</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#minimize-error-cues">http://www.w3.org/TR/WCAG20/#minimize-error-cues</a></li>
 </ul>
 <h2>Selector</h2>
@@ -539,7 +539,7 @@ Otherwise you may annoy your users.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">[role=&quot;presentation&quot;]</code> is a good idea for any <code class="styleguide">&lt;table&gt;</code> used for layout, but a bad thing for a data table. Double check this!</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-53-a-pour-chaque-tableau-de-mise-en-forme-le-contenu-linaris-reste-t-il-comprhensible-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-53-a-pour-chaque-tableau-de-mise-en-forme-le-contenu-linaris-reste-t-il-comprhensible-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-3">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-3</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence">http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence</a></li>
 </ul>
 <h2>Selector</h2>
@@ -581,7 +581,7 @@ Otherwise you may annoy your users.</p>
 <p class="styleguide">A link opening new tab or window should warn user about its behaviour.
 You could use a <code class="styleguide">[title]</code>, for example.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-132-a-dans-chaque-page-web-pour-chaque-ouverture-de-nouvelle-fentre-lutilisateur-est-il-averti-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-132-a-dans-chaque-page-web-pour-chaque-ouverture-de-nouvelle-fentre-lutilisateur-est-il-averti-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-2</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context">http://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H33.html">http://www.w3.org/TR/WCAG-TECHS/H33.html</a></li>
@@ -628,7 +628,7 @@ Otherwise you may make your users to call anubody.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">[scope]</code> can be col or row (and nothing else) and it has to be relevant.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-57-a-pour-chaque-tableau-de-donnes-la-technique-approprie-permettant-dassocier-chaque-cellule-avec-ses-en-ttes-est-elle-utilise-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-57-a-pour-chaque-tableau-de-donnes-la-technique-approprie-permettant-dassocier-chaque-cellule-avec-ses-en-ttes-est-elle-utilise-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-7">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-7</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H63.html">http://www.w3.org/TR/WCAG-TECHS/H63.html</a></li>
 </ul>
@@ -708,7 +708,7 @@ Otherwise you may make your users to call anubody.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">[title]</code> on any graphic content should be equal to <code class="styleguide">[aria-label]</code> or <code class="styleguide">[alt]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-13-a-pour-chaque-image-porteuse-dinformation-ayant-une-alternative-textuelle-cette-alternative-est-elle-pertinente-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-13-a-pour-chaque-image-porteuse-dinformation-ayant-une-alternative-textuelle-cette-alternative-est-elle-pertinente-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-3">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-3</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#text-equiv-all">http://www.w3.org/TR/WCAG20/#text-equiv-all</a></li>
 <li><a href="http://www.w3.org/WAI/tutorials/images/decision-tree/">http://www.w3.org/WAI/tutorials/images/decision-tree/</a></li>
 <li><a href="http://www.w3.org/TR/html51/semantics.html#alt">http://www.w3.org/TR/html51/semantics.html#alt</a></li>
@@ -735,10 +735,10 @@ Otherwise you may make your users to call anubody.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">&lt;video&gt;</code> or <code class="styleguide">&lt;audio&gt;</code> needs a few things to be accessible, like a transcript, subtitles, controls. This kind of things.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-41-a-chaque-mdia-temporel-pr-enregistr-a-t-il-si-ncessaire-une-transcription-textuelle-ou-une-audio-description-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-41-a-chaque-mdia-temporel-pr-enregistr-a-t-il-si-ncessaire-une-transcription-textuelle-ou-une-audio-description-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-1">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-1</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt">http://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#media-equiv-audio-desc">http://www.w3.org/TR/WCAG20/#media-equiv-audio-desc</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-413-aaa-chaque-mdia-temporel-synchronis-ou-seulement-vido-a-t-il-si-ncessaire-une-transcription-textuelle-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-413-aaa-chaque-mdia-temporel-synchronis-ou-seulement-vido-a-t-il-si-ncessaire-une-transcription-textuelle-hors-cas-particuliers-</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-13">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-13</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#media-equiv-text-doc">http://www.w3.org/TR/WCAG20/#media-equiv-text-doc</a></li>
 </ul>
 <h2>Selector</h2>

--- a/docs/build/errors.html
+++ b/docs/build/errors.html
@@ -191,8 +191,8 @@
 <p class="styleguide"><code class="styleguide">[width]</code> and <code class="styleguide">[height]</code> are presentation informations.
 Therefore it shouldn&#39;t be used in markup, except for <code class="styleguide">&lt;img&gt;</code>. Use CSS instead.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-prsentation-de-linformation">http://references.modernisation.gouv.fr/referentiel-technique-0#title-prsentation-de-linformation</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-101-a-dans-le-site-web-des-feuilles-de-styles-sont-elles-utilises-pour-contrler-la-prsentation-de-linformation-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-101-a-dans-le-site-web-des-feuilles-de-styles-sont-elles-utilises-pour-contrler-la-prsentation-de-linformation-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#presentation">http://references.modernisation.gouv.fr/rgaa/criteres.html#presentation</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-10-1-">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-10-1-</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence">http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence</a></li>
 </ul>
@@ -240,8 +240,8 @@ Use <code class="styleguide">[disabled]</code> and <code class="styleguide">[rea
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">&lt;button&gt;</code> should either have content or an <code class="styleguide">[aria-label]</code>, <code class="styleguide">[aria-labelledby]</code> or <code class="styleguide">[title]</code>. Those attributes, if present, should not be empty.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-1211-formulaires">http://references.modernisation.gouv.fr/referentiel-technique-0#title-1211-formulaires</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#formulaire">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#formulaire</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H91.html">http://www.w3.org/TR/WCAG-TECHS/H91.html</a></li>
 <li><a href="https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L193">https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L193</a></li>
@@ -277,8 +277,8 @@ Use <code class="styleguide">[disabled]</code> and <code class="styleguide">[rea
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">[aria-label]</code>, <code class="styleguide">[aria-labelledby]</code> or <code class="styleguide">[title]</code> on a <code class="styleguide">&lt;button&gt;</code> must not be empty.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-1211-formulaires">http://references.modernisation.gouv.fr/referentiel-technique-0#title-1211-formulaires</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#formulaire">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#formulaire</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H91.html">http://www.w3.org/TR/WCAG-TECHS/H91.html</a></li>
 <li><a href="https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L193">https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L193</a></li>
@@ -331,7 +331,7 @@ Use <code class="styleguide">[disabled]</code> and <code class="styleguide">[rea
 <p class="styleguide">An empty link should have a label, within <code class="styleguide">[title]</code>, <code class="styleguide">[aria-label]</code> or targeted by <code class="styleguide">[aria-labelledby]</code>.
 By the way, why would you use an empty link?</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-65-a-dans-chaque-page-web-chaque-lien-lexception-des-ancres-a-t-il-un-intitul-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-65-a-dans-chaque-page-web-chaque-lien-lexception-des-ancres-a-t-il-un-intitul-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-6-5">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-6-5</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#text-equiv-all">http://www.w3.org/TR/WCAG20/#text-equiv-all</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-link">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-link</a></li>
@@ -523,7 +523,7 @@ Yep. Digits, two hyphens, or hyphen followed by a digit.</p>
 <h2>Description</h2>
 <p class="styleguide">An <code class="styleguide">&lt;img&gt;</code> must have an <code class="styleguide">[alt]</code>. Always.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-11-a-chaque-image-a-t-elle-une-alternative-textuelle-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-11-a-chaque-image-a-t-elle-une-alternative-textuelle-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-1">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-1</a></li>
 <li><a href="http://www.w3.org/WAI/tutorials/images/decision-tree/">http://www.w3.org/WAI/tutorials/images/decision-tree/</a></li>
 <li><a href="http://www.w3.org/TR/html51/semantics.html#alt">http://www.w3.org/TR/html51/semantics.html#alt</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#text-equiv-all">http://www.w3.org/TR/WCAG20/#text-equiv-all</a></li>
@@ -559,7 +559,7 @@ Yep. Digits, two hyphens, or hyphen followed by a digit.</p>
 <h2>Description</h2>
 <p class="styleguide">A <code class="styleguide">&lt;label&gt;</code> is labelling something, in theory.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-111-a-chaque-champ-de-formulaire-a-t-il-une-tiquette-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-111-a-chaque-champ-de-formulaire-a-t-il-une-tiquette-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-1">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-1</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#minimize-error-cues">http://www.w3.org/TR/WCAG20/#minimize-error-cues</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
@@ -587,7 +587,7 @@ Yep. Digits, two hyphens, or hyphen followed by a digit.</p>
 <h2>Description</h2>
 <p class="styleguide">How to label a field? You have a few choices: <code class="styleguide">[id]</code>, <code class="styleguide">[title]</code>, <code class="styleguide">[aria-label]</code> and <code class="styleguide">[aria-labelledby]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-111-a-chaque-champ-de-formulaire-a-t-il-une-tiquette-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-111-a-chaque-champ-de-formulaire-a-t-il-une-tiquette-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-1">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-1</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#minimize-error-cues">http://www.w3.org/TR/WCAG20/#minimize-error-cues</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
@@ -615,9 +615,9 @@ Yep. Digits, two hyphens, or hyphen followed by a digit.</p>
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;html&gt;</code> must indicate to User Agents the human language used in the document.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-83-a-dans-chaque-page-web-la-langue-par-dfaut-est-elle-prsente-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-83-a-dans-chaque-page-web-la-langue-par-dfaut-est-elle-prsente-</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-langue-par-dfaut">http://references.modernisation.gouv.fr/referentiel-technique-0#title-langue-par-dfaut</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-84-a-pour-chaque-page-web-ayant-une-langue-par-dfaut-le-code-de-langue-est-il-pertinent-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-84-a-pour-chaque-page-web-ayant-une-langue-par-dfaut-le-code-de-langue-est-il-pertinent-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-3">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-3</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa/glossaire.html#langue-par-dfaut">http://references.modernisation.gouv.fr/rgaa/glossaire.html#langue-par-dfaut</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-4">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-4</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#meaning-doc-lang-id">http://www.w3.org/TR/WCAG20/#meaning-doc-lang-id</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H57.html">http://www.w3.org/TR/WCAG-TECHS/H57.html</a></li>
 </ul>
@@ -644,8 +644,8 @@ Yep. Digits, two hyphens, or hyphen followed by a digit.</p>
 <p class="styleguide">The <code class="styleguide">title&gt;</code> tag is the first thing read aloud by screen readers — to announce the page&hellip; title — and also the first thing displayed on search engines&#39; results pages.</p><p class="styleguide">We also use the <code class="styleguide">:blank</code> pseudo-class for the single space case, but at this time its support is very poor.
 We also use the <code class="styleguide">:-moz-only-whitespace</code> pseudo-class, which is an alias of <code class="styleguide">:blank</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-85-a-chaque-page-web-a-t-elle-un-titre-de-page-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-85-a-chaque-page-web-a-t-elle-un-titre-de-page-</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#titre-de-page">http://references.modernisation.gouv.fr/referentiel-technique-0#titre-de-page</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-5">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-5</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa/glossaire.html#titrePage">http://references.modernisation.gouv.fr/rgaa/glossaire.html#titrePage</a></li>
 <li><a href="http://www.w3.org/TR/html5/document-metadata.html#the-title-element">http://www.w3.org/TR/html5/document-metadata.html#the-title-element</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#navigation-mechanisms-title">http://www.w3.org/TR/WCAG20/#navigation-mechanisms-title</a></li>
 <li><a href="http://www.w3.org/WAI/WCAG20/quickref/#qr-navigation-mechanisms-title">http://www.w3.org/WAI/WCAG20/quickref/#qr-navigation-mechanisms-title</a></li>
@@ -721,7 +721,7 @@ We also use the <code class="styleguide">:-moz-only-whitespace</code> pseudo-cla
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;iframe&gt;</code> needs a <code class="styleguide">[title]</code> in order to tell the user what to expect inside the iframe.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-21-a-chaque-cadre-en-ligne-a-t-il-un-titre-de-cadre-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-21-a-chaque-cadre-en-ligne-a-t-il-un-titre-de-cadre-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-2-1">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-2-1</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H64.html">http://www.w3.org/TR/WCAG-TECHS/H64.html</a></li>
 </ul>
@@ -747,7 +747,7 @@ We also use the <code class="styleguide">:-moz-only-whitespace</code> pseudo-cla
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;input&gt;</code> needs a <code class="styleguide">[type]</code> in order to tell the user what kind of data is wanted.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1111-aa-dans-chaque-formulaire-le-contrle-de-saisie-est-il-accompagn-si-ncessaire-de-suggestions-facilitant-la-correction-des-erreurs-de-saisie-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1111-aa-dans-chaque-formulaire-le-contrle-de-saisie-est-il-accompagn-si-ncessaire-de-suggestions-facilitant-la-correction-des-erreurs-de-saisie-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-11">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-11</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#minimize-error-suggestions">http://www.w3.org/TR/WCAG20/#minimize-error-suggestions</a></li>
 </ul>
 <h2>Selector</h2>
@@ -775,7 +775,7 @@ We also use the <code class="styleguide">:-moz-only-whitespace</code> pseudo-cla
 <p class="styleguide">How to label a <code class="styleguide">[reset]</code>, <code class="styleguide">[submit]</code> or <code class="styleguide">[button]</code> type input?
 You still have a few choices: <code class="styleguide">[value]</code>, <code class="styleguide">[title]</code>, <code class="styleguide">[aria-label]</code> and <code class="styleguide">[aria-labelledby]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H91.html">http://www.w3.org/TR/WCAG-TECHS/H91.html</a></li>
 </ul>
@@ -864,7 +864,7 @@ You still have a few choices: <code class="styleguide">[value]</code>, <code cla
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;optgroup&gt;</code> needs a <code class="styleguide">[label]</code> to explain what&#39;s inside the group.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-118-a-dans-chaque-formulaire-chaque-liste-de-choix-est-elle-structure-de-manire-pertinente-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-118-a-dans-chaque-formulaire-chaque-liste-de-choix-est-elle-structure-de-manire-pertinente-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-8">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-8</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H85.html">http://www.w3.org/TR/WCAG-TECHS/H85.html</a></li>
 <li><a href="http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/H85">http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/H85</a></li>
 </ul>
@@ -943,7 +943,7 @@ However, semantics tags and attributes aiming to organize datas mustn&#39;t be u
 * <code class="styleguide">[headers]</code>;
 * <code class="styleguide">[colgroup]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-58-a-chaque-tableau-de-mise-en-forme-ne-doit-pas-utiliser-dlments-propres-aux-tableaux-de-donnes-cette-rgle-est-elle-respecte-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-58-a-chaque-tableau-de-mise-en-forme-ne-doit-pas-utiliser-dlments-propres-aux-tableaux-de-donnes-cette-rgle-est-elle-respecte-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-8">http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-8</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/F46.html">http://www.w3.org/TR/WCAG-TECHS/F46.html</a></li>
 <li><a href="http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/F49">http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/F49</a></li>
 </ul>

--- a/docs/build/obsolete.html
+++ b/docs/build/obsolete.html
@@ -107,7 +107,7 @@
 <p class="styleguide">Many, many attributes are obsolete in HTML5. You should care!</p>
 <h2>Reference</h2>
 <ul class="styleguide"><li><a href="http://www.w3.org/TR/html5/obsolete.html#obsolete">http://www.w3.org/TR/html5/obsolete.html#obsolete</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2</a></li>
 </ul>
 <h2>Selector</h2>
 <div class="codeBlock cssExample">
@@ -199,7 +199,7 @@
 <p class="styleguide">Many, many tags are obsolete in HTML5. You should care!</p>
 <h2>Reference</h2>
 <ul class="styleguide"><li><a href="http://www.w3.org/TR/html5/obsolete.html#obsolete">http://www.w3.org/TR/html5/obsolete.html#obsolete</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2</a></li>
 </ul>
 <h2>Selector</h2>
 <div class="codeBlock cssExample">

--- a/docs/build/warnings.html
+++ b/docs/build/warnings.html
@@ -194,8 +194,8 @@
 <h2>Description</h2>
 <p class="styleguide">A time-based media like <code class="styleguide">&lt;audio&gt;</code> or <code class="styleguide">&lt;video&gt;</code> should not <code class="styleguide">[autoplay]</code>, because it can be quite surprising for the user.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-418-a-chaque-son-dclench-automatiquement-est-il-contrlable-par-lutilisateur-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-418-a-chaque-son-dclench-automatiquement-est-il-contrlable-par-lutilisateur-</a></li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1317-a-dans-chaque-page-web-chaque-contenu-en-mouvement-ou-clignotant-est-il-contrlable-par-lutilisateur-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1317-a-dans-chaque-page-web-chaque-contenu-en-mouvement-ou-clignotant-est-il-contrlable-par-lutilisateur-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-18">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-18</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-17">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-13-17</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio">http://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio</a></li>
 <li><a href="http://www.punkchip.com/autoplay-is-bad-for-all-users/">http://www.punkchip.com/autoplay-is-bad-for-all-users/</a></li>
 </ul>
@@ -220,7 +220,7 @@
 <h2>Description</h2>
 <p class="styleguide">A time-based media like <code class="styleguide">&lt;audio&gt;</code> or <code class="styleguide">&lt;video&gt;</code> would be easier to use if <code class="styleguide">[controls]</code> are activated for the user.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-420-a-la-consultation-de-chaque-mdia-temporel-est-elle-si-ncessaire-contrlable-par-le-clavier-et-la-souris-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-420-a-la-consultation-de-chaque-mdia-temporel-est-elle-si-ncessaire-contrlable-par-le-clavier-et-la-souris-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-20">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-4-20</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#media-equiv-audio-desc">http://www.w3.org/TR/WCAG20/#media-equiv-audio-desc</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable">http://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#keyboard-operation-trapping">http://www.w3.org/TR/WCAG20/#keyboard-operation-trapping</a></li>
@@ -249,7 +249,7 @@
 That should be double-checked.</p>
 <h2>References</h2>
 <ul class="styleguide"><li>BP160 OpQuast</li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-12-a-pour-chaque-image-de-dcoration-ayant-une-alternative-textuelle-cette-alternative-est-elle-vide-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-12-a-pour-chaque-image-de-dcoration-ayant-une-alternative-textuelle-cette-alternative-est-elle-vide-</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-2</a></li>
 <li><a href="http://www.w3.org/WAI/tutorials/images/decision-tree/">http://www.w3.org/WAI/tutorials/images/decision-tree/</a></li>
 <li><a href="http://www.w3.org/TR/html51/semantics.html#alt">http://www.w3.org/TR/html51/semantics.html#alt</a></li>
 <li><a href="http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all">http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all</a></li>
@@ -323,7 +323,7 @@ empty if they have at least one source specified through <code class="styleguide
 <p class="styleguide">Any abbreviation should give an explanation about its meaning, at least on its first occurrence.</p>
 <h2>References</h2>
 <ul class="styleguide"><li>BP160 OpQuast</li>
-<li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-94-aaa-dans-chaque-page-web-la-premire-occurrence-de-chaque-abrviation-permet-elle-den-connatre-la-signification-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-94-aaa-dans-chaque-page-web-la-premire-occurrence-de-chaque-abrviation-permet-elle-den-connatre-la-signification-</a></li>
+<li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-9-4">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-9-4</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#meaning-located">http://www.w3.org/TR/WCAG20/#meaning-located</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/G70.html">http://www.w3.org/TR/WCAG-TECHS/G70.html</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/G97.html">http://www.w3.org/TR/WCAG-TECHS/G97.html</a></li>
@@ -353,7 +353,7 @@ empty if they have at least one source specified through <code class="styleguide
 <p class="styleguide"><code class="styleguide">&lt;legend&gt;</code> must be a <code class="styleguide">&lt;fieldset&gt;</code>&#39;s<code class="styleguide">:first-child</code>.
 Always.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-116-a-dans-chaque-formulaire-chaque-regroupement-de-champs-de-formulaire-a-t-il-une-lgende-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-116-a-dans-chaque-formulaire-chaque-regroupement-de-champs-de-formulaire-a-t-il-une-lgende-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-16">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-16</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#minimize-error-cues">http://www.w3.org/TR/WCAG20/#minimize-error-cues</a></li>
 <li><a href="https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L218">https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L218</a></li>
@@ -385,7 +385,7 @@ Always.</p>
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;figure&gt;</code> needs <code class="styleguide">[role=&quot;group&quot;]</code> for accessibility reason.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-110-a-chaque-lgende-dimage-est-elle-si-ncessaire-correctement-relie-limage-correspondante-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-110-a-chaque-lgende-dimage-est-elle-si-ncessaire-correctement-relie-limage-correspondante-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-10">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-10</a></li>
 <li><a href="http://www.w3.org/WAI/tutorials/images/decision-tree/">http://www.w3.org/WAI/tutorials/images/decision-tree/</a></li>
 <li><a href="http://www.w3.org/TR/html51/semantics.html#alt">http://www.w3.org/TR/html51/semantics.html#alt</a></li>
 </ul>
@@ -439,7 +439,7 @@ The only exception shall be bookmarklets.</p>
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;dt&gt;</code> and <code class="styleguide">&lt;dd&gt;</code> should be direct adjacent siblings, and nothing else. Although multiple <code class="styleguide">&lt;dd&gt;</code> may follow a single <code class="styleguide">&lt;dt&gt;</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-parses">http://www.w3.org/TR/WCAG20/#ensure-compat-parses</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L312">https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L312</a></li>
@@ -483,7 +483,7 @@ The only exception shall be bookmarklets.</p>
 <p class="styleguide"><code class="styleguide">&lt;dt&gt;</code> and <code class="styleguide">&lt;dd&gt;</code> should be direct children of <code class="styleguide">&lt;dl&gt;</code>.
 Any other imbrication may be a crime somewhere.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-parses">http://www.w3.org/TR/WCAG20/#ensure-compat-parses</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L318">https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L318</a></li>
@@ -533,7 +533,7 @@ Any other imbrication may be a crime somewhere.</p>
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;figcaption&gt;</code> doesn&#39;t make sense outside a <code class="styleguide">&lt;figure&gt;</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-parses">http://www.w3.org/TR/WCAG20/#ensure-compat-parses</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-figcaption-element">http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-figcaption-element</a></li>
@@ -558,7 +558,7 @@ Any other imbrication may be a crime somewhere.</p>
 <h2>Description</h2>
 <p class="styleguide">The only child allowed in <code class="styleguide">&lt;ul&gt;</code> and <code class="styleguide">&lt;ol&gt;</code> is <code class="styleguide">&lt;li&gt;</code> - and the converse is also true.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-8-2</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-parses">http://www.w3.org/TR/WCAG20/#ensure-compat-parses</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#ensure-compat-rsv">http://www.w3.org/TR/WCAG20/#ensure-compat-rsv</a></li>
 <li><a href="https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L313">https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L313</a></li>
@@ -708,7 +708,7 @@ You could use a <code class="styleguide">&lt;span&gt;</code> instead.</p>
 * a <code class="styleguide">&lt;title&gt;</code> child;
 * or a <code class="styleguide">&lt;desc&gt;</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-11-a-chaque-image-a-t-elle-une-alternative-textuelle-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-11-a-chaque-image-a-t-elle-une-alternative-textuelle-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-1">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-1-1</a></li>
 <li><a href="http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all">http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/F65.html">http://www.w3.org/TR/WCAG-TECHS/F65.html</a></li>
 </ul>
@@ -827,7 +827,7 @@ They must not be used as wrappers!</p>
 <p class="styleguide">Your styles should be driven by a CSS file. That&#39;s it.
 And no, JS shouldn&#39;t manipulate styles: it&#39;s better to play with classes, for example.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-101-a-dans-le-site-web-des-feuilles-de-styles-sont-elles-utilises-pour-contrler-la-prsentation-de-linformation-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-101-a-dans-le-site-web-des-feuilles-de-styles-sont-elles-utilises-pour-contrler-la-prsentation-de-linformation-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-10-1">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-10-1</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence">http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence</a></li>
 </ul>
@@ -852,7 +852,7 @@ And no, JS shouldn&#39;t manipulate styles: it&#39;s better to play with classes
 <p class="styleguide"><code class="styleguide">&lt;caption&gt;</code> is needed for data <code class="styleguide">&lt;table&gt;</code>.
 And it must be the <code class="styleguide">:first-child</code>, by the way.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-54-a-chaque-tableau-de-donnes-a-t-il-un-titre-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-54-a-chaque-tableau-de-donnes-a-t-il-un-titre-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-4">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-4</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
 <li><a href="http://www.w3.org/TR/html5/tabular-data.html#the-caption-element">http://www.w3.org/TR/html5/tabular-data.html#the-caption-element</a></li>
 <li><a href="http://www.w3.org/TR/WCAG-TECHS/H39.html">http://www.w3.org/TR/WCAG-TECHS/H39.html</a></li>
@@ -909,7 +909,7 @@ And it must be the <code class="styleguide">:first-child</code>, by the way.</p>
 <p class="styleguide">A lonely <code class="styleguide">&lt;tr&gt;</code> can be a symptom of a table used for layout.
 Should be double checked!</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-53-a-pour-chaque-tableau-de-mise-en-forme-le-contenu-linaris-reste-t-il-comprhensible-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-53-a-pour-chaque-tableau-de-mise-en-forme-le-contenu-linaris-reste-t-il-comprhensible-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-3">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-3</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence">http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence</a></li>
 </ul>
 <h2>Selector</h2>
@@ -996,7 +996,7 @@ Should be double checked!</p>
 <h2>Description</h2>
 <p class="styleguide"><code class="styleguide">&lt;th&gt;</code> strongly needs an <code class="styleguide">[id]</code> or a <code class="styleguide">[scope]</code>.</p>
 <h2>References</h2>
-<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-57-a-pour-chaque-tableau-de-donnes-la-technique-approprie-permettant-dassocier-chaque-cellule-avec-ses-en-ttes-est-elle-utilise-">http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-57-a-pour-chaque-tableau-de-donnes-la-technique-approprie-permettant-dassocier-chaque-cellule-avec-ses-en-ttes-est-elle-utilise-</a></li>
+<ul class="styleguide"><li><a href="http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-7">http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-5-7</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic">http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic</a></li>
 <li><a href="http://www.w3.org/TR/WCAG20-TECHS/H43.html">http://www.w3.org/TR/WCAG20-TECHS/H43.html</a></li>
 </ul>

--- a/sass/themes/_advice.scss
+++ b/sass/themes/_advice.scss
@@ -249,7 +249,7 @@ A link opening new tab or window should warn user about its behaviour.
 You could use a `[title]`, for example.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-132-a-dans-chaque-page-web-pour-chaque-ouverture-de-nouvelle-fentre-lutilisateur-est-il-averti->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-13-2>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs>
 * <http://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context>
 * <http://www.w3.org/TR/WCAG-TECHS/H33.html>
@@ -282,8 +282,8 @@ category: Advices
 A link to a file should indicate the file format, the file size and if different from the main document, the file language.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-136-a-dans-chaque-page-web-pour-chaque-fichier-en-tlchargement-des-informations-relatives-sa-consultation-sont-elles-prsentes-hors-cas-particuliers->
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-137-a-dans-chaque-page-web-chaque-document-bureautique-en-tlchargement-possde-t-il-si-ncessaire-une-version-accessible>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-13-6>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-13-7>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs>
 * <http://www.w3.org/TR/WCAG-TECHS/H33.html>
 
@@ -341,7 +341,7 @@ category: Advices
 Some ARIA roles should be unique: at least `[main]`, `[search]`, `[banner]`, `[contentinfo]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1210-a-dans-chaque-page-web-les-groupes-de-liens-importants-menu-barre-de-navigation-et-la-zone-de-contenu-sont-ils-identifis-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-12-10>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip>
 
 ##Selector
@@ -377,7 +377,7 @@ category: Advices
 A `[class]` or `[id]` containing search may carry the search ARIA `[role]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1210-a-dans-chaque-page-web-les-groupes-de-liens-importants-menu-barre-de-navigation-et-la-zone-de-contenu-sont-ils-identifis-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-12-10>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip>
 
 ##Selector
@@ -416,7 +416,7 @@ category: Advices
 A `[required]` or `[aria-required]` should be visually understandable.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1110-a-dans-chaque-formulaire-le-contrle-de-saisie-est-il-utilis-de-manire-pertinente->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-10>
 * <http://www.w3.org/TR/WCAG20/#minimize-error-cues>
 
 ##Selector
@@ -459,7 +459,7 @@ category: Advices
 A `[hidden]` or `[aria-hidden]` may not be a good idea if hiding content.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1013-a-pour-chaque-page-web-les-textes-cachs-sont-ils-correctement-affichs-pour-tre-restitus-par-les-technologies-dassistance->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-10-13>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 
 ##Selector
@@ -520,10 +520,10 @@ category: Advices
 A `<video>` or `<audio>` needs a few things to be accessible, like a transcript, subtitles, controls. This kind of things.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-41-a-chaque-mdia-temporel-pr-enregistr-a-t-il-si-ncessaire-une-transcription-textuelle-ou-une-audio-description-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-4-1>
 * <http://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt>
 * <http://www.w3.org/TR/WCAG20/#media-equiv-audio-desc>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-413-aaa-chaque-mdia-temporel-synchronis-ou-seulement-vido-a-t-il-si-ncessaire-une-transcription-textuelle-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-4-13>
 * <http://www.w3.org/TR/WCAG20/#media-equiv-text-doc>
 
 ##Selector
@@ -554,7 +554,7 @@ category: Advices
 A `[title]` on any graphic content should be equal to `[aria-label]` or `[alt]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-13-a-pour-chaque-image-porteuse-dinformation-ayant-une-alternative-textuelle-cette-alternative-est-elle-pertinente-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-3>
 * <http://www.w3.org/TR/WCAG20/#text-equiv-all>
 * <http://www.w3.org/WAI/tutorials/images/decision-tree/>
 * <http://www.w3.org/TR/html51/semantics.html#alt>
@@ -616,7 +616,7 @@ category: Advices
 A `[scope]` can be col or row (and nothing else) and it has to be relevant.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-57-a-pour-chaque-tableau-de-donnes-la-technique-approprie-permettant-dassocier-chaque-cellule-avec-ses-en-ttes-est-elle-utilise->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-7>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
 * <http://www.w3.org/TR/WCAG-TECHS/H63.html>
 
@@ -664,7 +664,7 @@ category: Advices
 A `[role="presentation"]` is a good idea for any `<table>` used for layout, but a bad thing for a data table. Double check this!
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-53-a-pour-chaque-tableau-de-mise-en-forme-le-contenu-linaris-reste-t-il-comprhensible->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-3>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence>
 
 ##Selector

--- a/sass/themes/_error.scss
+++ b/sass/themes/_error.scss
@@ -77,7 +77,7 @@ An empty link should have a label, within `[title]`, `[aria-label]` or targeted 
 By the way, why would you use an empty link?
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-65-a-dans-chaque-page-web-chaque-lien-lexception-des-ancres-a-t-il-un-intitul->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-6-5>
 * <http://www.w3.org/TR/WCAG20/#text-equiv-all>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-link>
@@ -146,7 +146,7 @@ category: Errors
 An `<img>` must have an `[alt]`. Always.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-11-a-chaque-image-a-t-elle-une-alternative-textuelle->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-1>
 * <http://www.w3.org/WAI/tutorials/images/decision-tree/>
 * <http://www.w3.org/TR/html51/semantics.html#alt>
 * <http://www.w3.org/TR/WCAG20/#text-equiv-all>
@@ -256,7 +256,7 @@ category: Errors
 A `<label>` is labelling something, in theory.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-111-a-chaque-champ-de-formulaire-a-t-il-une-tiquette->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-1>
 * <http://www.w3.org/TR/WCAG20/#minimize-error-cues>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
@@ -292,7 +292,7 @@ category: Errors
 How to label a field? You have a few choices: `[id]`, `[title]`, `[aria-label]` and `[aria-labelledby]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-111-a-chaque-champ-de-formulaire-a-t-il-une-tiquette->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-1>
 * <http://www.w3.org/TR/WCAG20/#minimize-error-cues>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
@@ -329,7 +329,7 @@ How to label a `[reset]`, `[submit]` or `[button]` type input?
 You still have a few choices: `[value]`, `[title]`, `[aria-label]` and `[aria-labelledby]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <http://www.w3.org/TR/WCAG-TECHS/H91.html>
 
@@ -365,8 +365,8 @@ category: Errors
 A `<button>` should either have content or an `[aria-label]`, `[aria-labelledby]` or `[title]`. Those attributes, if present, should not be empty.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-1211-formulaires>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent->
+* <http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#formulaire>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <http://www.w3.org/TR/WCAG-TECHS/H91.html>
 * <https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L193>
@@ -414,8 +414,8 @@ category: Errors
 `[aria-label]`, `[aria-labelledby]` or `[title]` on a `<button>` must not be empty.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-1211-formulaires>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-119-a-dans-chaque-formulaire-lintitul-de-chaque-bouton-est-il-pertinent->
+* <http://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#formulaire>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-9>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <http://www.w3.org/TR/WCAG-TECHS/H91.html>
 * <https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L193>
@@ -563,7 +563,7 @@ category: Errors
 `<input>` needs a `[type]` in order to tell the user what kind of data is wanted.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1111-aa-dans-chaque-formulaire-le-contrle-de-saisie-est-il-accompagn-si-ncessaire-de-suggestions-facilitant-la-correction-des-erreurs-de-saisie->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-11>
 * <http://www.w3.org/TR/WCAG20/#minimize-error-suggestions>
 
 ##Selector
@@ -597,7 +597,7 @@ category: Errors
 `<optgroup>` needs a `[label]` to explain what's inside the group.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-118-a-dans-chaque-formulaire-chaque-liste-de-choix-est-elle-structure-de-manire-pertinente->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-8>
 * <http://www.w3.org/TR/WCAG-TECHS/H85.html>
 * <http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/H85>
 
@@ -639,7 +639,7 @@ category: Errors
 `<iframe>` needs a `[title]` in order to tell the user what to expect inside the iframe.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-21-a-chaque-cadre-en-ligne-a-t-il-un-titre-de-cadre->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-2-1>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <http://www.w3.org/TR/WCAG-TECHS/H64.html>
 
@@ -710,9 +710,9 @@ category: Errors
 `<html>` must indicate to User Agents the human language used in the document.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-83-a-dans-chaque-page-web-la-langue-par-dfaut-est-elle-prsente->
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-langue-par-dfaut>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-84-a-pour-chaque-page-web-ayant-une-langue-par-dfaut-le-code-de-langue-est-il-pertinent->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-3>
+* <http://references.modernisation.gouv.fr/rgaa-accessibilite/glossaire.html#langue-par-dfaut>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-4>
 * <http://www.w3.org/TR/WCAG20/#meaning-doc-lang-id>
 * <http://www.w3.org/TR/WCAG-TECHS/H57.html>
 
@@ -755,7 +755,7 @@ However, semantics tags and attributes aiming to organize datas mustn't be used.
 * `[colgroup]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-58-a-chaque-tableau-de-mise-en-forme-ne-doit-pas-utiliser-dlments-propres-aux-tableaux-de-donnes-cette-rgle-est-elle-respecte->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-8>
 * <http://www.w3.org/TR/WCAG-TECHS/F46.html>
 * <http://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140916/F49>
 
@@ -818,8 +818,8 @@ category: Errors
 Therefore it shouldn't be used in markup, except for `<img>`. Use CSS instead.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-prsentation-de-linformation>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-101-a-dans-le-site-web-des-feuilles-de-styles-sont-elles-utilises-pour-contrler-la-prsentation-de-linformation->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#presentation>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-10-1->
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence>
 
@@ -1042,8 +1042,8 @@ We also use the `:blank` pseudo-class for the single space case, but at this tim
 We also use the `:-moz-only-whitespace` pseudo-class, which is an alias of `:blank`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-85-a-chaque-page-web-a-t-elle-un-titre-de-page->
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#titre-de-page>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-5>
+* <http://references.modernisation.gouv.fr/rgaa/glossaire.html#titrePage>
 * <http://www.w3.org/TR/html5/document-metadata.html#the-title-element>
 * <http://www.w3.org/TR/WCAG20/#navigation-mechanisms-title>
 * <http://www.w3.org/WAI/WCAG20/quickref/#qr-navigation-mechanisms-title>

--- a/sass/themes/_obsolete.scss
+++ b/sass/themes/_obsolete.scss
@@ -12,7 +12,7 @@ Many, many tags are obsolete in HTML5. You should care!
 
 ##Reference
 * <http://www.w3.org/TR/html5/obsolete.html#obsolete>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-2>
 
 ##Selector
 ```css_example
@@ -89,7 +89,7 @@ Many, many attributes are obsolete in HTML5. You should care!
 
 ##Reference
 * <http://www.w3.org/TR/html5/obsolete.html#obsolete>
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-2>
 
 ##Selector
 ```css_example

--- a/sass/themes/_warning.scss
+++ b/sass/themes/_warning.scss
@@ -12,7 +12,7 @@ category: Warnings
 The only child allowed in `<ul>` and `<ol>` is `<li>` - and the converse is also true.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-2>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-parses>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L313>
@@ -52,7 +52,7 @@ category: Warnings
 `<dt>` and `<dd>` should be direct adjacent siblings, and nothing else. Although multiple `<dd>` may follow a single `<dt>`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-2>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-parses>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L312>
@@ -95,7 +95,7 @@ category: Warnings
 Any other imbrication may be a crime somewhere.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-2>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-parses>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L318>
@@ -142,7 +142,7 @@ category: Warnings
 `<figcaption>` doesn't make sense outside a `<figure>`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-82-a-pour-chaque-page-web-le-code-source-est-il-valide-selon-le-type-de-document-spcifi-hors-cas-particuliers->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-8-2>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-parses>
 * <http://www.w3.org/TR/WCAG20/#ensure-compat-rsv>
 * <http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-figcaption-element>
@@ -173,7 +173,7 @@ category: Warnings
 `<figure>` needs `[role="group"]` for accessibility reason.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-110-a-chaque-lgende-dimage-est-elle-si-ncessaire-correctement-relie-limage-correspondante->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-10>
 * <http://www.w3.org/WAI/tutorials/images/decision-tree/>
 * <http://www.w3.org/TR/html51/semantics.html#alt>
 
@@ -344,7 +344,7 @@ category: Warnings
 Always.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-116-a-dans-chaque-formulaire-chaque-regroupement-de-champs-de-formulaire-a-t-il-une-lgende->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-11-6>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
 * <http://www.w3.org/TR/WCAG20/#minimize-error-cues>
 * <https://github.com/Heydon/REVENGE.CSS/blob/master/revenge.css#L218>
@@ -381,7 +381,7 @@ Any abbreviation should give an explanation about its meaning, at least on its f
 
 ##References
 * BP160 OpQuast
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-94-aaa-dans-chaque-page-web-la-premire-occurrence-de-chaque-abrviation-permet-elle-den-connatre-la-signification->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-9-4>
 * <http://www.w3.org/TR/WCAG20/#meaning-located>
 * <http://www.w3.org/TR/WCAG-TECHS/G70.html>
 * <http://www.w3.org/TR/WCAG-TECHS/G97.html>
@@ -420,7 +420,7 @@ That should be double-checked.
 
 ##References
 * BP160 OpQuast
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-12-a-pour-chaque-image-de-dcoration-ayant-une-alternative-textuelle-cette-alternative-est-elle-vide->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-2>
 * <http://www.w3.org/WAI/tutorials/images/decision-tree/>
 * <http://www.w3.org/TR/html51/semantics.html#alt>
 * <http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all>
@@ -473,7 +473,7 @@ Otherwise it should have a `[role="presentation"]`, and should not have any of t
 * or a `<desc>`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-11-a-chaque-image-a-t-elle-une-alternative-textuelle->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-1>
 * <http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all>
 * <http://www.w3.org/TR/WCAG-TECHS/F65.html>
 
@@ -507,8 +507,8 @@ category: Warnings
 A time-based media like `<audio>` or `<video>` should not `[autoplay]`, because it can be quite surprising for the user.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-418-a-chaque-son-dclench-automatiquement-est-il-contrlable-par-lutilisateur->
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-1317-a-dans-chaque-page-web-chaque-contenu-en-mouvement-ou-clignotant-est-il-contrlable-par-lutilisateur->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-4-18>
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-13-17>
 * <http://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio>
 * <http://www.punkchip.com/autoplay-is-bad-for-all-users/>
 
@@ -540,7 +540,7 @@ category: Warnings
 A time-based media like `<audio>` or `<video>` would be easier to use if `[controls]` are activated for the user.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-420-a-la-consultation-de-chaque-mdia-temporel-est-elle-si-ncessaire-contrlable-par-le-clavier-et-la-souris->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-4-20>
 * <http://www.w3.org/TR/WCAG20/#media-equiv-audio-desc>
 * <http://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable>
 * <http://www.w3.org/TR/WCAG20/#keyboard-operation-trapping>
@@ -648,7 +648,7 @@ A lonely `<tr>` can be a symptom of a table used for layout.
 Should be double checked!
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-53-a-pour-chaque-tableau-de-mise-en-forme-le-contenu-linaris-reste-t-il-comprhensible->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-3>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence>
 
 ##Selector
@@ -685,7 +685,7 @@ category: Warnings
 And it must be the `:first-child`, by the way.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-54-a-chaque-tableau-de-donnes-a-t-il-un-titre->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-4>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
 * <http://www.w3.org/TR/html5/tabular-data.html#the-caption-element>
 * <http://www.w3.org/TR/WCAG-TECHS/H39.html>
@@ -817,7 +817,7 @@ category: Warnings
 `<th>` strongly needs an `[id]` or a `[scope]`.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-57-a-pour-chaque-tableau-de-donnes-la-technique-approprie-permettant-dassocier-chaque-cellule-avec-ses-en-ttes-est-elle-utilise->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-5-7>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
 * <http://www.w3.org/TR/WCAG20-TECHS/H43.html>
 
@@ -996,7 +996,7 @@ Your styles should be driven by a CSS file. That's it.
 And no, JS shouldn't manipulate styles: it's better to play with classes, for example.
 
 ##References
-* <http://references.modernisation.gouv.fr/referentiel-technique-0#title-critre-101-a-dans-le-site-web-des-feuilles-de-styles-sont-elles-utilises-pour-contrler-la-prsentation-de-linformation->
+* <http://references.modernisation.gouv.fr/rgaa/criteres.html#crit-10-1->
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic>
 * <http://www.w3.org/TR/WCAG20/#content-structure-separation-sequence>
 


### PR DESCRIPTION
Bonjour,

Petite contribution pour éviter un travail fastidieux (issue #240) : tous les liens vers le référentiel RGAA 3.0 ont été modifiés pour rediriger vers RGAA 3 2016.

Bonne journée,