### PR TITLE
add style field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "a11y.css",
   "description": "This file aims to warn front-end devs about mistakes and potential accessibility failures - but it also helps to rate client-side code and to spot its weaknesses.",
   "version": "3.2.1",
+  "style": "css/a11y-en.css",
   "author": {
     "name": "Gaël Poupard",
     "url": "http://www.ffoodd.fr",


### PR DESCRIPTION
This adds a `style` field to `package.json` to help out tooling find the right file by default. The [sheetify](https://github.com/stackcss/sheetify) and [css-modules](https://github.com/css-modules/css-modules) packages in particular are fond of this.

With `sheetify` the workflow currently is:

```sh
$ npm install a11y.css
```

```js
var css = require('sheetify')
css('a11y.css/css/a11y-en.css')
```

With this patch this then becomes:
```js
var css = require('sheetify')
css('a11y.css')
```

I feel this would make using this project slightly more accessible for those seeking to use it. Thanks!