### PR TITLE
remove two links, add one for role=group on figure

### DIFF
--- a/warnings.html
+++ b/warnings.html
@@ -526,8 +526,7 @@ Always.</p>
 <p class="styleguide"><code class="styleguide">&lt;figure&gt;</code> needs <code class="styleguide">[role=&quot;group&quot;]</code> for accessibility reason.</p>
 <h2>References</h2>
 <ul class="styleguide"><li><a href="https://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-10">https://references.modernisation.gouv.fr/rgaa/criteres.html#crit-1-10</a></li>
-<li><a href="https://www.w3.org/WAI/tutorials/images/decision-tree/">https://www.w3.org/WAI/tutorials/images/decision-tree/</a></li>
-<li><a href="https://www.w3.org/TR/html51/semantics.html#alt">https://www.w3.org/TR/html51/semantics.html#alt</a></li>
+<li><a href="https://www.w3.org/WAI/tutorials/images/groups/">https://www.w3.org/WAI/tutorials/images/groups/</a></li>
 </ul>
 <h2>Selector</h2>
 <div class="codeBlock cssExample">


### PR DESCRIPTION
Two of the links for `group="role"` on `figure` tags didn't lead to any pages talking about such. Added a link supporting the warning recommendation.