### PR TITLE
catch error when sending message looks to fix error

### DIFF
--- a/webextension/scripts/checkalts.js
+++ b/webextension/scripts/checkalts.js
@@ -39,11 +39,14 @@ btnCheckalts.addEventListener('click', function () {
 			icons: icons,
 			strings: strings
 		});
-	});
+	}).catch(onError);
 	var checked = this.getAttribute('aria-checked') === 'true' || false;
 	this.setAttribute('aria-checked', !checked);
 	storeCheckAltsStatus(!checked);
 });
+function onError(error) {
+    console.error(`Error: ${error}`);
+}
 
 function checkAltsOnload() {
 	let getStatus = browser.storage.local.get("checkAltsStatus");

--- a/webextension/scripts/textspacing.js
+++ b/webextension/scripts/textspacing.js
@@ -27,11 +27,15 @@ btnTextspacing.addEventListener('click', function () {
 		browser.tabs.sendMessage(tabs[0].id, {
 			a11ycss_action: "textspacing"
 		});
-	});
+	}).catch(onError);
 	var checked = this.getAttribute('aria-checked') === 'true' || false;
 	this.setAttribute('aria-checked', !checked);
 	storeTextSpacingStatus(!checked);
 });
+
+function onError(error) {
+    console.error(`Error: ${error}`);
+}
 
 function textSpacingOnload() {
 	let getStatus = browser.storage.local.get("textSpacingStatus");


### PR DESCRIPTION
Adding an error catching + console.error remove the error from webextension on chrome.

Doesn't see the error in the console itself so, I don't know if the error is thrown in non-active tab?

Maybe need to check if "tabs[0]" exist before sending message? don't know if tabs object could be empty