### PR TITLE
Moving chromium's manifest to V3

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -1,14 +1,14 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "a11y.css",
 	"description": "a11y.css provides warnings about possible risks and mistakes that exist in HTML.",
 	"version": "1.3.0",
 	"permissions": [
 		"activeTab",
 		"storage",
-		"tabs"
+		"scripting"
 	],
-	"browser_action": {
+	"action": {
 		"default_title": "a11y.css",
 		"default_popup": "popup/index.html",
 		"default_icon": {
@@ -17,11 +17,8 @@
 		}
 	},
 	"background": {
-		"scripts": [
-          "/scripts/browser-polyfill.min.js",
-          "/scripts/background/main.js"
-        ],
-        "persistent": true
+		"service_worker": ["/scripts/background/main.js"],
+    "persistent": true
 	},
 	"content_scripts": [
 		{
@@ -29,7 +26,6 @@
 				"<all_urls>"
 			],
 			"js": [
-				"/scripts/browser-polyfill.min.js",
 				"/scripts/injected/checkalts.js",
 				"/scripts/injected/textspacing.js"
 			],


### PR DESCRIPTION
First look at ffoodd/a11y.css-webextension#1, only moved the manifest file itself. 

BAckground scripts need to move to service workers, and `tab.executeScript()` needs to move to the new `scripting` permission. More info in the related issue.