### PR TITLE
[Actions] Skip verifying dead links from Twitter, they're 403'd

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,4 +42,4 @@ jobs:
           paths: docs
           recurse: true
           verbosity: error
-          skip: "docs/*, https://opensource.org, https://codepen.io"
+          skip: "docs/*, https://opensource.org, https://codepen.io, https://twitter.com"


### PR DESCRIPTION
When pushing code and documentation, GitHub Actions verify dead links.  
There are 3 links from Twitter that fail Linkinator: the response is always 403 even if those 3 tweets are still there (I verified manually).

Very probably, Twitter chose to ban this type of use or it comes from the free API use shutdown... You can do that for $44B (or must do that if you lose $1B/mo or whatever).

The 3 (undead?) links are:
* https://twitter.com/WebPlatformNews/status/1346492730223058946
* https://twitter.com/fvsch/status/921748801542639616
* https://twitter.com/KittyGiraudel/status/801475801397030912
