### PR TITLE
source elements within a picture element can contain width/height. Se…

### DIFF
--- a/sass/themes/_error.scss
+++ b/sass/themes/_error.scss
@@ -877,8 +877,8 @@ Therefore it shouldn't be used in markup, except for `<img>`. Use CSS instead.
 
 ### Selector
 ```css
-:not(img, object, embed, svg, canvas)[width],
-:not(img, object, embed, svg, canvas)[height]
+:not(img, object, embed, svg, canvas, picture > source)[width],
+:not(img, object, embed, svg, canvas, picture > source)[height]
 ```
 
 ### Test
@@ -886,8 +886,8 @@ Therefore it shouldn't be used in markup, except for `<img>`. Use CSS instead.
 <p width="20">Damned! I feel sooo strait :(</p>
 ```
 */
-:not(img, object, embed, svg, canvas)[width],
-:not(img, object, embed, svg, canvas)[height] {
+:not(img, object, embed, svg, canvas, picture > source)[width],
+:not(img, object, embed, svg, canvas, picture > source)[height] {
   @include error('dimensions');
 
   @include void-tags {


### PR DESCRIPTION
A picture element can contain one or more source elements. Those source elements can have width and height attributes since the picture tag is providing art direction for the images. 

https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element